### PR TITLE
Fix for the 'Failed to get image from www.gstatic.com'

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ Then add a line like this:
 0 */2 * * * PATH_TO_SCRIPT/earthwall.sh
 ```
 This is an example for changing the wallpaper every 2 hours. Change PATH_TO_SCRIPT accordingly.
+
+# Dependencies
+
+Usually works out of the box, but may require wget in some OSX installations which does not install it by default.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ Then add a line like this:
 ```
 This is an example for changing the wallpaper every 2 hours. Change PATH_TO_SCRIPT accordingly.
 
-# Dependencies
+## Dependencies
 
 Usually works out of the box, but may require wget in some OSX installations which does not install it by default.

--- a/earthwall.sh
+++ b/earthwall.sh
@@ -34,10 +34,13 @@ if [ $? -ne 0 ]; then
 fi
 
 # Set image url, name and location
-image_url=`cat $HOME/Pictures/earthwall/.index.html | grep prettyearth | grep 'https://www.gstatic.com/prettyearth/assets/full/[0-9]\{0,6\}.jpg' -m 1 -o`
+image_url=`cat $HOME/Pictures/earthwall/.index.html | grep prettyearth | grep 'https://www.gstatic.com/prettyearth/assets/full/[0-9]\{0,6\}.jpg' -m 1 -o | head -1`
 image_name=`echo $image_url | grep '[0-9]\{0,6\}.jpg' -m 1 -o`
-cat $HOME/Pictures/earthwall/.index.html | grep title=\"View | grep -o 'View.*in' | sed 's/View //g' | sed 's/ in//g' > $HOME/Pictures/earthwall/.image_location
-image_location=`cat $HOME/Pictures/earthwall/.image_location | sed 's/, /,/g' | sed 's/ /_/g'`
+
+#TODO: Find a way to retrieve image location. Possibly from title html tags?
+#cat $HOME/Pictures/earthwall/.index.html | awk -vRS="</title>" '/<title>/{gsub(/.*<title>|\n+/,"");print;exit}' > $HOME/Pictures/earthwall/.image_location
+#image_location=`cat $HOME/Pictures/earthwall/.image_location | sed 's/, /,/g' | sed 's/ /_/g'`
+#image_location=test
 
 # Get image
 /usr/local/bin/wget -q $image_url -O $HOME/Pictures/earthwall/$image_location-$image_name 2> /dev/null


### PR DESCRIPTION
It seems since the script was written gstatic.com changed its website html which in turn broke the script. I've put in a few fixes but didn't understand what you meant by image location. Is it the physical location displayed by earthwall? Maybe can add other image sources (splashy etc)? I've searched the net for a simple wallpaper changer but haven't found any and I think this can be the one!